### PR TITLE
Add Trivy Security Scanning GitHub Action

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,58 @@
+name: Trivy Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 8 * * 1' # Run every Monday at 8:00 UTC
+
+jobs:
+  trivy-scan:
+    name: Trivy Security Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Docker Build
+        run: docker build -t adx-mcp-server:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner for Docker image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'adx-mcp-server:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-docker-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+
+      - name: Upload Docker image scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-docker-results.sarif'


### PR DESCRIPTION
## Description

This PR adds a Trivy security scanning GitHub Action that runs automatically on pull requests and pushes to the main branch. This helps identify security vulnerabilities in both the repository code and the Docker image.

### Changes Made

- Added `.github/workflows/trivy-scan.yml` workflow file
- Configured two Trivy scans:
  1. Repository filesystem scan to check for vulnerabilities in dependencies
  2. Docker image scan to check for vulnerabilities in the container image
- Set up SARIF report generation for GitHub Security tab integration
- Configured to run on:
  - Pull requests to main
  - Pushes to main
  - Weekly schedule (Monday at 8:00 UTC) for regular security checks

### Security Benefits

- Early detection of vulnerabilities in the codebase and dependencies
- Prevention of introducing vulnerable code into the main branch
- Regular automated security audits
- Results visible in GitHub Security tab for easier tracking and remediation

### Reference

This implementation follows the guidance from [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#using-trivy-to-scan-your-git-repo).
