### PR TITLE
Add Trivy Security Scanning

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,53 @@
+name: Trivy Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Schedule daily scan
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  scan-repo:
+    name: Scan Repository for Vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  scan-image:
+    name: Scan Docker Image for Vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t adx-mcp-server:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner on Docker image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'adx-mcp-server:${{ github.sha }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
This PR adds Trivy security scanning to the repository as per the requirements. The implementation follows the guidelines from the [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#using-trivy-to-scan-your-git-repo) GitHub repository.

## Changes

- Added a new GitHub workflow file: `.github/workflows/trivy.yml`
- The workflow is triggered on:
  - Push to main branch
  - Pull requests to main branch
  - Daily schedule (midnight UTC)
  
## Features

1. **Repository scanning**:
   - Scans the entire repository for vulnerabilities in code and dependencies
   - Ignores unfixed vulnerabilities (reducing noise)
   - Focuses on CRITICAL and HIGH severity issues
   - Uploads results to GitHub Security tab in SARIF format

2. **Docker image scanning**:
   - Builds the Docker image
   - Scans for vulnerabilities in the OS and library packages
   - Fails the workflow if CRITICAL or HIGH vulnerabilities are found
   - Ignores unfixed vulnerabilities

This implementation will help identify security vulnerabilities before they reach production, enhancing the overall security posture of the project.
