### PR TITLE
Add SSE transport mode support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,14 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 # Set environment variables for ADX MCP Server
 ENV PYTHONUNBUFFERED=1
+ENV ADX_MCP_HOST=0.0.0.0
+ENV ADX_MCP_PORT=8000
 
-# when running the container, add ADX_CLUSTER_URL and ADX_DATABASE environment variables
+# Expose the port for SSE mode
+EXPOSE 8000
+
+# when running the container, you can override the default transport mode with arguments
+# e.g. docker run -it --rm -p 8000:8000 adx-mcp-server --transport sse
 ENTRYPOINT ["adx-mcp-server"]
 
 # Label the image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 
 services:
+  # Standard STDIO mode service
   adx-mcp-server:
     build:
       context: .
@@ -15,4 +16,22 @@ services:
       - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
     stdin_open: true  # Keep STDIN open even if not attached
     tty: true        # Allocate a pseudo-TTY
+    command: ["--transport", "stdio"]
     # For debugging/interactive use only - normally the MCP server runs with stdio transport
+
+  # SSE mode service
+  adx-mcp-server-sse:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"  # Expose the SSE port
+    environment:
+      - ADX_CLUSTER_URL=${ADX_CLUSTER_URL}
+      - ADX_DATABASE=${ADX_DATABASE}
+      - AZURE_TENANT_ID=${AZURE_TENANT_ID}
+      - AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
+      - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
+      - ADX_MCP_HOST=0.0.0.0
+      - ADX_MCP_PORT=8000
+    command: ["--transport", "sse"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "azure-identity",
     "python-dotenv",
     "pyproject-toml>=0.1.0",
+    "fastapi>=0.103.1",
+    "uvicorn>=0.23.2",
 ]
 
 [project.optional-dependencies]
@@ -22,6 +24,7 @@ dev = [
 
 [project.scripts]
 adx-mcp-server = "adx_mcp_server.main:run_server"
+adx-mcp-server-sse = "adx_mcp_server.main:run_server"
 
 [tool.setuptools]
 packages = ["adx_mcp_server"]

--- a/src/adx_mcp_server/main.py
+++ b/src/adx_mcp_server/main.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 import sys
 import dotenv
-from adx_mcp_server.server import mcp, config
+import argparse
+import os
+import uvicorn
+from fastapi import FastAPI
+from adx_mcp_server.server import mcp, config, SSE_HOST, SSE_PORT, create_sse_server
 
 def setup_environment():
     if dotenv.load_dotenv():
@@ -27,17 +31,79 @@ def setup_environment():
     
     return True
 
-def run_server():
-    """Main entry point for the Azure Data Explorer MCP Server"""
+def create_app():
+    """Create a FastAPI application for SSE mode"""
+    app = FastAPI(title="Azure Data Explorer MCP Server")
+    
+    # Mount the SSE handler at the root path
+    app.mount("/", create_sse_server(mcp))
+    
+    # Health check endpoint
+    @app.get("/health")
+    def health_check():
+        return {"status": "healthy", "service": "ADX MCP Server"}
+    
+    return app
+
+def run_server(transport_mode="stdio", host=None, port=None):
+    """Main entry point for the Azure Data Explorer MCP Server
+    
+    Args:
+        transport_mode (str): The transport mode to use ("stdio" or "sse")
+        host (str, optional): The host to bind to in SSE mode. Defaults to SSE_HOST env var or "0.0.0.0".
+        port (int, optional): The port to bind to in SSE mode. Defaults to SSE_PORT env var or 8000.
+    """
     # Setup environment
     if not setup_environment():
         sys.exit(1)
     
     print("\nStarting Azure Data Explorer MCP Server...")
-    print("Running server in standard mode...")
     
-    # Run the server with the stdio transport
-    mcp.run(transport="stdio")
+    if transport_mode == "sse":
+        # Use the provided host/port or fall back to environment/defaults
+        sse_host = host or SSE_HOST
+        sse_port = port or SSE_PORT
+        
+        print(f"Running server in SSE mode on {sse_host}:{sse_port}...")
+        
+        # Create the FastAPI app
+        app = create_app()
+        
+        # Start Uvicorn server
+        uvicorn.run(app, host=sse_host, port=sse_port, log_level="info")
+    else:
+        # Default to STDIO mode
+        print("Running server in STDIO mode...")
+        
+        # Run the server with the stdio transport
+        mcp.run(transport="stdio")
 
 if __name__ == "__main__":
-    run_server()
+    # Set up command-line argument parsing
+    parser = argparse.ArgumentParser(description="Azure Data Explorer MCP Server")
+    parser.add_argument(
+        "--transport", 
+        choices=["stdio", "sse"], 
+        default="stdio",
+        help="Transport mode to use (default: stdio)"
+    )
+    parser.add_argument(
+        "--host", 
+        default=None,
+        help="Host to bind to in SSE mode (default: from env or 0.0.0.0)"
+    )
+    parser.add_argument(
+        "--port", 
+        type=int,
+        default=None,
+        help="Port to bind to in SSE mode (default: from env or 8000)"
+    )
+    
+    args = parser.parse_args()
+    
+    # Run the server with the specified transport mode and options
+    run_server(
+        transport_mode=args.transport,
+        host=args.host, 
+        port=args.port
+    )

--- a/src/adx_mcp_server/server.py
+++ b/src/adx_mcp_server/server.py
@@ -6,12 +6,24 @@ from typing import Any, Dict, List, Optional, Union
 from dataclasses import dataclass
 
 import dotenv
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP, create_sse_server
 from azure.identity import DefaultAzureCredential
 from azure.kusto.data import KustoClient, KustoConnectionStringBuilder
 
 dotenv.load_dotenv()
-mcp = FastMCP("Azure Data Explorer MCP")
+
+# Get SSE configuration from environment
+SSE_HOST = os.environ.get("ADX_MCP_HOST", "0.0.0.0")
+SSE_PORT = int(os.environ.get("ADX_MCP_PORT", "8000"))
+SSE_LOG_LEVEL = os.environ.get("ADX_MCP_LOG_LEVEL", "INFO")
+
+# Initialize FastMCP with SSE configuration
+mcp = FastMCP(
+    name="Azure Data Explorer MCP",
+    host=SSE_HOST,
+    port=SSE_PORT,
+    log_level=SSE_LOG_LEVEL
+)
 
 @dataclass
 class ADXConfig:


### PR DESCRIPTION
## Description

This PR adds support for Server-Sent Events (SSE) transport mode to the ADX MCP Server, providing a web-based integration option in addition to the existing STDIO mode.

## Changes

- Added FastAPI and Uvicorn dependencies for SSE support
- Modified `server.py` to properly configure FastMCP with SSE parameters
- Refactored `main.py` to support both STDIO and SSE modes with command-line options
- Updated Docker configuration to expose the SSE port and support both modes
- Updated documentation in README.md with detailed instructions for using SSE mode
- Added environment variable configuration for SSE host, port, and log level

## Testing

The implementation allows running the server in either STDIO mode (default) or SSE mode by specifying the `--transport sse` command-line option. The SSE mode starts an HTTP server that serves MCP over Server-Sent Events, allowing web-based integration with MCP clients.

## Usage

```bash
# Run in STDIO mode (default)
adx-mcp-server

# Run in SSE mode
adx-mcp-server --transport sse --host 0.0.0.0 --port 8000
```

For Docker:
```bash
# Run in SSE mode with Docker
docker run -it --rm -p 8000:8000 adx-mcp-server --transport sse
```

## Related Documentation
- [Model Context Protocol](https://modelcontextprotocol.io)
- [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)