### PR TITLE
Add support for Azure Workload Identity credential

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,10 @@
 # Azure Data Explorer configuration
 ADX_CLUSTER_URL=https://yourcluster.region.kusto.windows.net
 ADX_DATABASE=your_database
+
+# Workload Identity configuration (optional)
+# Set to 'true' to explicitly use WorkloadIdentityCredential
+# ADX_USE_WORKLOAD_IDENTITY=true
+# ADX_TENANT_ID=your_tenant_id
+# ADX_CLIENT_ID=your_client_id
+# ADX_TOKEN_FILE_PATH=/var/run/secrets/azure/tokens/azure-identity-token

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y \
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
- 
+
 COPY --from=uv /root/.local /root/.local
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
 
@@ -51,5 +51,5 @@ ENTRYPOINT ["adx-mcp-server"]
 
 # Label the image
 LABEL maintainer="pab1it0" \
-      description="Azure Data Explorer MCP Server" \
-      version="1.0.6"
+    description="Azure Data Explorer MCP Server" \
+    version="1.0.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adx_mcp_server"
-version = "1.0.6"
+version = "1.0.7"
 description = "MCP server for Azure Data Explorer integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/adx_mcp_server/main.py
+++ b/src/adx_mcp_server/main.py
@@ -23,7 +23,15 @@ def setup_environment():
     print(f"Azure Data Explorer configuration:")
     print(f"  Cluster: {config.cluster_url}")
     print(f"  Database: {config.database}")
-    print(f"  Authentication: Using DefaultAzureCredential")
+    
+    if config.use_workload_identity and config.tenant_id and config.client_id:
+        print(f"  Authentication: Using WorkloadIdentityCredential")
+        print(f"    Tenant ID: {config.tenant_id}")
+        print(f"    Client ID: {config.client_id}")
+        if config.token_file_path:
+            print(f"    Token File Path: {config.token_file_path}")
+    else:
+        print(f"  Authentication: Using DefaultAzureCredential")
     
     return True
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "adx-mcp-server"
-version = "1.0.4"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },


### PR DESCRIPTION
Add support for Azure Workload Identity credential
Description
This PR adds explicit support for Azure Workload Identity credential authentication when running in AKS environments. While DefaultAzureCredential already includes WorkloadIdentityCredential in its authentication chain, this PR provides explicit configuration options for better control and debugging.
Changes

Added configuration options for explicit WorkloadIdentityCredential usage
Updated credential initialization logic to use WorkloadIdentityCredential when explicitly configured
Updated startup logging to show which authentication method is being used
Added documentation in README.md for the new Workload Identity support
Added new environment variables to .env.template

New Environment Variables

ADX_USE_WORKLOAD_IDENTITY - Set to 'true' to explicitly use WorkloadIdentityCredential
ADX_TENANT_ID - Azure tenant ID
ADX_CLIENT_ID - Client/application ID for the managed identity
ADX_TOKEN_FILE_PATH - Optional path to the token file (defaults to Azure standard path)

Documentation
The README.md has been updated with:

Information about Workload Identity support
Example environment variable configuration
Docker usage with Workload Identity
Claude Desktop configuration updates

Implementation Details
The implementation follows the Azure Python SDK best practices for handling Workload Identity credentials. If the workload identity configuration is incomplete, the system will fall back to using DefaultAzureCredential.
Testing
Tested that:

DefaultAzureCredential still works as before when no workload identity configuration is provided
Explicit WorkloadIdentityCredential is used when properly configured
Configuration validation is properly logged at startup

Related Issues